### PR TITLE
update exports + examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,18 @@ yarn add @phosphor-icons/core
 
 ## Assets
 
-This package expoeses all icon SVG assets, grouped by weight, under the `/assets` directory, E.G.  `/assests/<weight>/kebab-name-<weight>.svg`. and be used as needed for custom implementations or ports. Your framework and build tooling may require custom type declarations to recognize  and transform `"*.svg"` files into modules.
+This package exposes all icons as SVG assets, grouped by weight, under the `/assets` directory (i.e.  `/assets/<weight>/<kebab-name>-<weight>.svg`). These files can be used as needed for custom implementations or ports. Your framework and build tooling may require custom type declarations to recognize and transform `"*.svg"` files into modules.
+
+### Note for Vite users 
+
+As of Vite 4.0.4 (current at the time of writing), a bug in one of its dependencies prevents wildcard exports from being resolved. This will be [fixed](https://github.com/vitejs/vite/commit/00a79ec88472cbcc767c1187f919ce372215f573) in Vite 4.1.
+
+### Example
 
 ```ts
 import ghostDuotone from "@phosphor-icons/core/duotone/ghost-duotone.svg";
 ```
-
+#### Using [SVGR](https://react-svgr.com/docs/configuration-files):
 
 ```tsx
 import { ReactComponent as GhostDuotone } from "@phosphor-icons/core/duotone/ghost-duotone.svg";

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ As of Vite 4.0.4 (current at the time of writing), a bug in one of its dependenc
 ```ts
 import ghostDuotone from "@phosphor-icons/core/duotone/ghost-duotone.svg";
 ```
-#### Using [SVGR](https://react-svgr.com/docs/configuration-files):
+
+#### Using [SVGR](https://react-svgr.com/docs/webpack/#use-with-url-loader-or-file-loader) (includes `create-react-app` projects):
 
 ```tsx
 import { ReactComponent as GhostDuotone } from "@phosphor-icons/core/duotone/ghost-duotone.svg";

--- a/package.json
+++ b/package.json
@@ -20,7 +20,13 @@
     "./assets/fill/*.svg": "./assets/fill/*.svg",
     "./assets/light/*.svg": "./assets/light/*.svg",
     "./assets/regular/*.svg": "./assets/regular/*.svg",
-    "./assets/thin/*.svg": "./assets/thin/*.svg"
+    "./assets/thin/*.svg": "./assets/thin/*.svg",
+    "./bold/*.svg": "./assets/bold/*.svg",
+    "./duotone/*.svg": "./assets/duotone/*.svg",
+    "./fill/*.svg": "./assets/fill/*.svg",
+    "./light/*.svg": "./assets/light/*.svg",
+    "./regular/*.svg": "./assets/regular/*.svg",
+    "./thin/*.svg": "./assets/thin/*.svg"
   },
   "types": "./dist/index.d.ts",
   "author": {


### PR DESCRIPTION
in regards to discussion in [ac17ee2](https://github.com/phosphor-icons/core/commit/ac17ee2bdcb8be058c9130c9e97201b407d0cc35#r98099990), I updated import docs and added the import style previously documented. I also fixed a couple typos and changed up the grammar one of the paragraphs. I can happily strip that change if requested :)