### PR TITLE
Create release github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release packages
+on: release
+jobs:
+  release:
+    strategy:
+      matrix:
+        packages: [flutter]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          repository: phosphor-icons/${{ matrix.packages }}
+          token: ${{ secrets.CI_PAT }}
+      - name: Setup Git
+        run: |
+          git config --global user.name "Automated Release"
+          git config --global user.email "friedtm@gmail.com"
+            - name: Create release
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.release.name }}
+          name: ${{ github.event.release.name }}
+          token: ${{ secrets.CI_PAT }}
+          body: ${{ github.event.release.body }}


### PR DESCRIPTION
To automate all repository I would recommend github actions.
I don't know if this currently works but I want to make a start.

On every release on this repository, it makes a release on the other repositories. Currently I only added flutter.
To use it you need to add the CI_PAT (personal access token) secret in the repository settings.
To automate the publishing of packages, we need to add additional github actions on every repository that will be triggered on release.