### PR TITLE
Add extensions to imports

### DIFF
--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,4 +1,4 @@
-import { IconEntry, IconCategory, FigmaCategory } from "./types";
+import { IconEntry, IconCategory, FigmaCategory } from "./types.js";
 
 export const icons: ReadonlyArray<IconEntry> = [
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./icons";
-export * from "./types";
+export * from "./icons.js";
+export * from "./types.js";


### PR DESCRIPTION
As per the Node ESM spec, file extensions are always required for relative imports, ref: https://nodejs.org/api/esm.html#terminology
I'm working on a better solidjs solution and this is currently a blocker for me