### PR TITLE
feat(lib): allow strong typing for icons

### DIFF
--- a/scripts/catalog.ts
+++ b/scripts/catalog.ts
@@ -41,7 +41,9 @@ async function main() {
       let fileString = `\
 import { IconEntry, IconCategory, FigmaCategory } from "./types";
 
-export const icons: ReadonlyArray<IconEntry> = [
+export type PhosphorIcon = typeof icons[number]
+
+export const icons = <const>[
 `;
 
       console.log(res.data.icons);
@@ -103,7 +105,7 @@ export const icons: ReadonlyArray<IconEntry> = [
       });
 
       fileString += `
-];
+] satisfies readonly IconEntry[];
 `;
 
       try {

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,5 +1,7 @@
 import { IconEntry, IconCategory, FigmaCategory } from "./types";
 
+export type PhosphorIcon = typeof icons[number]
+
 export const icons = <const>[
   {
     name: "address-book",

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,8 +1,8 @@
 import { IconEntry, IconCategory, FigmaCategory } from "./types";
 
-export type PhosphorIcon = typeof icons[number]
+export type PhosphorIcon = (typeof icons)[number];
 
-export const icons = <const>[
+export const icons = (<const>[
   {
     name: "address-book",
     pascal_name: "AddressBook",
@@ -6611,6 +6611,17 @@ export const icons = <const>[
     updated_in: 1.4,
   },
   {
+    name: "file-magnifying-glass",
+    pascal_name: "FileMagnifyingGlass",
+    alias: { name: "file-search", pascal_name: "FileSearch" },
+    categories: [IconCategory.OFFICE, IconCategory.EDITOR],
+    figma_category: FigmaCategory.OFFICE,
+    tags: ["documents", "files", "find", "locate", "browse", "missing"],
+    codepoint: 57912,
+    published_in: 1.0,
+    updated_in: 1.0,
+  },
+  {
     name: "file-minus",
     pascal_name: "FileMinus",
     categories: [IconCategory.OFFICE, IconCategory.EDITOR],
@@ -6673,20 +6684,6 @@ export const icons = <const>[
     codepoint: 60200,
     published_in: 1.4,
     updated_in: 1.4,
-  },
-  {
-    name: "file-search",
-    pascal_name: "FileSearch",
-    alias: {
-      name: "file-magnifying-glass",
-      pascal_name: "FileMagnifyingGlass",
-    },
-    categories: [IconCategory.OFFICE, IconCategory.EDITOR],
-    figma_category: FigmaCategory.OFFICE,
-    tags: ["documents", "files", "find", "locate", "browse", "missing"],
-    codepoint: 57912,
-    published_in: 1.0,
-    updated_in: 1.0,
   },
   {
     name: "file-sql",
@@ -16811,4 +16808,4 @@ export const icons = <const>[
     published_in: 1.0,
     updated_in: 1.0,
   },
-] satisfies ReadonlyArray<IconEntry>;
+]) satisfies readonly IconEntry[];

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,6 +1,6 @@
 import { IconEntry, IconCategory, FigmaCategory } from "./types";
 
-export const icons: ReadonlyArray<IconEntry> = [
+export const icons = <const>[
   {
     name: "address-book",
     pascal_name: "AddressBook",
@@ -16809,4 +16809,4 @@ export const icons: ReadonlyArray<IconEntry> = [
     published_in: 1.0,
     updated_in: 1.0,
   },
-];
+] satisfies ReadonlyArray<IconEntry>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,9 +56,9 @@ export interface IconEntry {
     name: string;
     pascal_name: string;
   };
-  categories: IconCategory[];
+  categories: readonly IconCategory[];
   figma_category: FigmaCategory;
-  tags: string[];
+  tags: readonly string[];
   codepoint: number;
   published_in: number;
   updated_in: number;


### PR DESCRIPTION
This PR adds a `const` constraint to the `icons` array exported by `src/icons.ts`, so the Typescript compiler will emit a much more useful declaration file which can later be used to strictly type valid icon names. It also exports a new `PhosphorIcon` type.

Instead of emitting this in `dist/icons.d.ts:

```typescript
export declare const icons: ReadonlyArray<IconEntry>;
```

With this PR the following will be emitted:

```typescript
export declare const icons: readonly [{
    readonly name: "address-book";
    readonly pascal_name: "AddressBook";
    readonly categories: readonly [IconCategory.COMMUNICATION];
    readonly figma_category: FigmaCategory.COMMUNICATION;
    readonly tags: readonly ["contacts", "roledex"];
    readonly codepoint: 59128;
    readonly published_in: 1.3;
    readonly updated_in: 1.3;
}, // ...
]
```

Now the following becomes possible:

```typescript
import { PhosphorIcon } from '@phosphor-icons/core'
declare const myComponent: (props: { icon: PhosphorIcon['name'] }) => any

myComponent({
  // this prop is strongly typed
  icon: 'address-book'
})
```

I believe this will hardly break anything. If it does, a separated export can be added.
