### PR TITLE
Add Elixir, Phoenix, and Ash icons link

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ type IconName = PhosphorIcon["name"];
 - [cellularmitosis/phosphor-uikit](https://github.com/cellularmitosis/phosphor-uikit) ▲ XCode asset catalog generator for Phosphor icons (Swift/UIKit)
 - [cjohansen/phosphor-clj](https://github.com/cjohansen/phosphor-clj) ▲ Phosphor icons as Hiccup for Clojure and ClojureScript
 - [codeat3/blade-phosphor-icons](https://github.com/codeat3/blade-phosphor-icons) ▲ Phosphor icons in your Laravel Blade views
+- [dennym/phosphor_icons_ex](https://github.com/dennym/phosphor_icons_ex) ▲ Phosphor icons for Elixir, Phoenix and Ash
 - [dreamRs/phosphor-r](https://github.com/dreamRs/phosphoricons) ▲ Phosphor icon wrapper for R documents and applications
 - [duongdev/phosphor-react-native](https://github.com/duongdev/phosphor-react-native) ▲ Phosphor icon component library for React Native
 - [haruaki07/phosphor-svelte](https://github.com/haruaki07/phosphor-svelte) ▲ Phosphor icons for Svelte apps


### PR DESCRIPTION
Since all the other packages for elixir either are outdated or have already and opinionated approach here is a plain package which just returns the svgs in functions that then can be used in components or straight up in EEx/HEEx.
It also auto updates itself via actions to ensure to always have version parity.